### PR TITLE
Add bottom search button and focus requester

### DIFF
--- a/app/src/main/java/com/example/campusguide/MainActivity.kt
+++ b/app/src/main/java/com/example/campusguide/MainActivity.kt
@@ -36,6 +36,7 @@ import com.example.campusguide.ui.accessibility.AccessibleAppRoot
 import com.example.campusguide.ui.accessibility.AccessibleText
 import com.example.campusguide.ui.accessibility.LocalAccessibilityState
 import com.example.campusguide.ui.accessibility.rememberAccessibilityState
+import androidx.compose.ui.focus.FocusRequester
 import com.example.campusguide.ui.components.NavigationBar
 import com.example.campusguide.ui.components.SearchBarWithProfile
 import com.example.campusguide.ui.screens.AccessibilityScreen
@@ -90,6 +91,7 @@ fun ConcordiaCampusGuideApp() {
     var searchCounter by rememberSaveable { mutableStateOf(0) }
     var topBarSuggestions by remember { mutableStateOf<List<com.example.campusguide.data.CampusBuilding>>(emptyList()) }
     var topBarSelectedBuilding by remember { mutableStateOf<com.example.campusguide.data.CampusBuilding?>(null) }
+    val searchFocusRequester = remember { FocusRequester() }
     val context = LocalContext.current
 
     val locationPermissionLauncher = rememberLauncherForActivityResult(
@@ -133,6 +135,9 @@ fun ConcordiaCampusGuideApp() {
                             searchQuery = "$searchQuery#$searchCounter",
                             topBarSelectedBuilding = topBarSelectedBuilding,
                             onTopBarBuildingConsumed = { topBarSelectedBuilding = null },
+                            onBottomSearchClick = {
+                                try { searchFocusRequester.requestFocus() } catch (_: IllegalStateException) {}
+                            },
                         )
                         AppDestinations.CALENDAR -> CalendarScreen()
                         AppDestinations.POI -> PlaceholderScreen("POI Screen", modifier)
@@ -140,6 +145,7 @@ fun ConcordiaCampusGuideApp() {
 
                     SearchBarWithProfile(
                         modifier = Modifier.padding(top = 35.dp),
+                        focusRequester = searchFocusRequester,
                         onSearchQueryChange = { query ->
                             topBarSuggestions = com.example.campusguide.data.buildingSuggestions(
                                 query = query,

--- a/app/src/main/java/com/example/campusguide/ui/components/SearchBar.kt
+++ b/app/src/main/java/com/example/campusguide/ui/components/SearchBar.kt
@@ -23,11 +23,14 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
@@ -49,12 +52,14 @@ import androidx.compose.foundation.lazy.items
 @Composable
 fun SearchBarWithProfile(
     modifier: Modifier = Modifier,
+    focusRequester: FocusRequester? = null,
     onSearchQueryChange: (String) -> Unit = {},
     onSearchSubmit: (String) -> Unit = {},
     onProfileClick: () -> Unit = {},
     suggestions: List<CampusBuilding> = emptyList(),
     onBuildingSelected: (CampusBuilding) -> Unit = {},
 ) {
+    val textFocusRequester = focusRequester ?: remember { FocusRequester() }
     var searchQuery by rememberSaveable { mutableStateOf("") }
     Column(modifier = modifier.fillMaxWidth()) {
         Surface(
@@ -94,7 +99,9 @@ fun SearchBarWithProfile(
                             searchQuery = it
                             onSearchQueryChange(it)
                         },
-                        modifier = Modifier.fillMaxWidth(),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .focusRequester(textFocusRequester),
                         textStyle = TextStyle(
                             color = MaterialTheme.colorScheme.onSurface,
                             fontSize = 16.sp
@@ -186,3 +193,4 @@ fun SearchBarWithProfilePreview() {
         SearchBarWithProfile()
     }
 }
+

--- a/app/src/main/java/com/example/campusguide/ui/screens/MapScreen.kt
+++ b/app/src/main/java/com/example/campusguide/ui/screens/MapScreen.kt
@@ -26,8 +26,14 @@ import android.provider.Settings
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -83,6 +89,7 @@ fun MapScreen(
     searchQuery: String = "",
     topBarSelectedBuilding: CampusBuilding? = null,
     onTopBarBuildingConsumed: () -> Unit = {},
+    onBottomSearchClick: () -> Unit = {},
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -570,12 +577,29 @@ fun MapScreen(
         )
 
 
-        // Campus Toggle
-        Box(
+        // Campus Toggle + round search shortcut button (same row)
+        Row(
             modifier = Modifier
                 .align(Alignment.BottomStart)
-                .padding(start = 76.dp, bottom = 10.dp)
+                .padding(start = 16.dp, bottom = 10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
+            Box(
+                modifier = Modifier
+                    .size(48.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surfaceVariant)
+                    .clickable(onClick = onBottomSearchClick)
+                    .semantics { contentDescription = "Bottom search button" },
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Search,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
             CampusToggle(
                 selectedCampus = selectedCampus,
                 onCampusSelected = { campus ->

--- a/app/src/test/java/com/example/campusguide/SearchBarTest.kt
+++ b/app/src/test/java/com/example/campusguide/SearchBarTest.kt
@@ -417,6 +417,39 @@ class SearchBarTest {
         }
     }
 
+    // Bottom search button tests
+
+    @Test
+    fun mapScreen_bottomSearchButton_isVisible() {
+        composeTestRule.setContent {
+            ConcordiaCampusGuideTheme {
+                CompositionLocalProvider(LocalAccessibilityState provides defaultState) {
+                    MapScreen()
+                }
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithContentDescription("Bottom search button").assertIsDisplayed()
+    }
+
+    @Test
+    fun mapScreen_bottomSearchButton_clickTriggersCallback() {
+        var clicked = false
+
+        composeTestRule.setContent {
+            ConcordiaCampusGuideTheme {
+                CompositionLocalProvider(LocalAccessibilityState provides defaultState) {
+                    MapScreen(onBottomSearchClick = { clicked = true })
+                }
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithContentDescription("Bottom search button").performClick()
+        assertTrue("Bottom search button on map should trigger callback", clicked)
+    }
+
   //Top search bar sets building as To: destination
 
     @Test


### PR DESCRIPTION
This pull request introduces a new floating search shortcut button to the map screen, allowing users to quickly focus the top search bar from the bottom of the screen. It also updates the `SearchBarWithProfile` component to support programmatic focus requests and adds comprehensive tests for the new UI element.

**Map Screen UI Enhancements:**

* Added a round floating search shortcut button to the bottom left of the map screen, making it easier for users to access the search functionality. This button triggers a callback to focus the top search bar when clicked. [[1]](diffhunk://#diff-2302c27b1ec2503b673a3f35e43ce633963bb2b111a8831356858066a299bbf2L573-R602) [[2]](diffhunk://#diff-2302c27b1ec2503b673a3f35e43ce633963bb2b111a8831356858066a299bbf2R92)
* Updated the `MapScreen` composable to accept an `onBottomSearchClick` callback, which is invoked when the new search button is pressed.

**Search Bar Focus Management:**

* Modified `SearchBarWithProfile` to accept an optional `FocusRequester` parameter, enabling programmatic focus of the search input. The modifier now applies `.focusRequester()` to the text field for focus control. [[1]](diffhunk://#diff-6941ef4b8d76a8cbe926b972e1ea41f8c676e2e2bb6d8c992fc99bf31bb07676R55-R62) [[2]](diffhunk://#diff-6941ef4b8d76a8cbe926b972e1ea41f8c676e2e2bb6d8c992fc99bf31bb07676L97-R104)
* Integrated focus management in `MainActivity` by creating and passing a `FocusRequester` to the top search bar and wiring the new bottom search button to request focus when pressed. [[1]](diffhunk://#diff-52da0350afc40372750e93063691055b3a4faf76c1e25c9ae5557ae8df5473b6R94) [[2]](diffhunk://#diff-52da0350afc40372750e93063691055b3a4faf76c1e25c9ae5557ae8df5473b6R138-R148)

**Testing Improvements:**

* Added UI tests to verify that the bottom search button is visible on the map screen and that clicking it triggers the appropriate callback.Introduce a FocusRequester in MainActivity and wire an onBottomSearchClick handler that requests focus on the top search field (wrapped in try/catch). Update SearchBarWithProfile to accept an optional FocusRequester (or remember one) and apply focusRequester to the TextField. Add a circular bottom search shortcut button to MapScreen that calls the callback and exposes a semantics contentDescription for testing. Add tests verifying the bottom search button is visible and invokes the provided callback when clicked.

Closes #178