### PR TITLE
[US-3.2]-Add shuttle schedule and next departure info 

### DIFF
--- a/app/src/main/java/com/example/campusguide/ui/components/ShuttleScheduleDialog.kt
+++ b/app/src/main/java/com/example/campusguide/ui/components/ShuttleScheduleDialog.kt
@@ -1,0 +1,128 @@
+package com.example.campusguide.ui.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.campusguide.ui.shuttle.ShuttleSchedule
+
+@Composable
+fun ShuttleScheduleDialog(onDismiss: () -> Unit) {
+    val scrollState = rememberScrollState()
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text("Shuttle schedule", fontWeight = FontWeight.Normal, fontSize = 18.sp)
+        },
+        text = {
+            Column(
+                modifier = Modifier
+                    .verticalScroll(scrollState)
+                    .fillMaxWidth()
+            ) {
+                // Scroll progress indicator
+                if (scrollState.maxValue > 0) {
+                    LinearProgressIndicator(
+                        progress = { scrollState.value.toFloat() / scrollState.maxValue },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 8.dp)
+                    )
+                }
+
+                Text(
+                    "Winter departure times",
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 20.sp
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    "Schedule in effect: Jan. 12 – Apr. 15, 2026",
+                    fontSize = 13.sp
+                )
+                Spacer(Modifier.height(6.dp))
+                Text(
+                    "The following departure times are approximate and may vary due to unexpected circumstances, traffic and weather.",
+                    fontStyle = FontStyle.Italic,
+                    fontSize = 12.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(Modifier.height(16.dp))
+
+                ScheduleSection(
+                    title = "Monday — Thursday",
+                    loyolaTimes = ShuttleSchedule.loyolaMonThur.map { it.toString() },
+                    sgwTimes = ShuttleSchedule.sgwMonThur.map { it.toString() }
+                )
+
+                Spacer(Modifier.height(16.dp))
+
+                ScheduleSection(
+                    title = "Friday",
+                    loyolaTimes = ShuttleSchedule.loyolaFriday.map { it.toString() },
+                    sgwTimes = ShuttleSchedule.sgwFriday.map { it.toString() }
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text("Close") }
+        },
+        shape = RoundedCornerShape(28.dp),
+        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+    )
+}
+
+@Composable
+private fun ScheduleSection(
+    title: String,
+    loyolaTimes: List<String>,
+    sgwTimes: List<String>
+) {
+    Text(title, fontWeight = FontWeight.Bold, fontSize = 15.sp)
+    Spacer(Modifier.height(6.dp))
+    Row(Modifier.fillMaxWidth()) {
+        // LOY column
+        Column(Modifier.weight(1f)) {
+            Text(
+                "LOY departures",
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 12.sp,
+                modifier = Modifier.align(Alignment.CenterHorizontally)
+            )
+            Spacer(Modifier.height(4.dp))
+            loyolaTimes.forEach { time ->
+                Text(
+                    time,
+                    fontSize = 13.sp,
+                    modifier = Modifier.align(Alignment.CenterHorizontally)
+                )
+            }
+        }
+        // SGW column
+        Column(Modifier.weight(1f)) {
+            Text(
+                "SGW departures",
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 12.sp,
+                modifier = Modifier.align(Alignment.CenterHorizontally)
+            )
+            Spacer(Modifier.height(4.dp))
+            sgwTimes.forEach { time ->
+                Text(
+                    time,
+                    fontSize = 13.sp,
+                    modifier = Modifier.align(Alignment.CenterHorizontally)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/campusguide/ui/components/ShuttleStopInfoCard.kt
+++ b/app/src/main/java/com/example/campusguide/ui/components/ShuttleStopInfoCard.kt
@@ -16,7 +16,11 @@ import androidx.compose.ui.unit.dp
 import com.example.campusguide.R
 import com.example.campusguide.data.ShuttleStop
 import com.example.campusguide.ui.accessibility.AccessibleText
-
+import com.example.campusguide.ui.shuttle.ShuttleSchedule
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 private val ShuttleBlue = Color(0xFF1565C0)
 
 @Composable
@@ -25,6 +29,22 @@ fun ShuttleStopInfoCard(
     isOperational: Boolean = true,
     onDismiss: () -> Unit
 ) {
+    var showSchedule by remember { mutableStateOf(false) }
+
+    if (showSchedule) {
+        ShuttleScheduleDialog(onDismiss = { showSchedule = false })
+        return
+    }
+
+    // Compute next departure
+    val nextDep = ShuttleSchedule.nextDeparture(stop.campus)
+    val nextDepText = if (nextDep != null) {
+        "Next departure: $nextDep"
+    } else {
+        val nextDay = ShuttleSchedule.nextDepartureNextDay(stop.campus)
+        if (nextDay != null) "No more departures today.\nNext departure: ${nextDay.first} ${nextDay.second}"
+        else "No more departures today."
+    }
     AlertDialog(
         onDismissRequest = onDismiss,
         title = {
@@ -67,6 +87,15 @@ fun ShuttleStopInfoCard(
                         baseFontSizeSp = 14f,
                         fallbackColor = MaterialTheme.colorScheme.onSurfaceVariant
                     )
+                    AccessibleText(
+                        text = nextDepText,
+                        baseFontSizeSp = 14f,
+                        forceFontWeight = FontWeight.SemiBold,
+                        fallbackColor = if (nextDep != null)
+                            MaterialTheme.colorScheme.onSurface
+                        else
+                            MaterialTheme.colorScheme.error
+                    )
                     val campusLabel = when (stop.campus) {
                         Campus.SGW -> "SGW"
                         Campus.LOYOLA -> "Loyola"
@@ -80,8 +109,16 @@ fun ShuttleStopInfoCard(
             }
         },
         confirmButton = {
-            TextButton(onClick = onDismiss) {
-                Text("OK")
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                if (isOperational) {
+                    Button(
+                        onClick = { showSchedule = true },
+                        colors = ButtonDefaults.buttonColors(containerColor = ShuttleBlue)
+                    ) {
+                        Text("View full schedule")
+                    }
+                }
+                TextButton(onClick = onDismiss) { Text("OK") }
             }
         },
         containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,

--- a/app/src/main/java/com/example/campusguide/ui/shuttle/ShuttleSchedule.kt
+++ b/app/src/main/java/com/example/campusguide/ui/shuttle/ShuttleSchedule.kt
@@ -1,0 +1,109 @@
+package com.example.campusguide.ui.shuttle
+
+import com.example.campusguide.ui.components.Campus
+import java.time.DayOfWeek
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+data class DepartureTime(val hour: Int, val minute: Int) {
+    val localTime: LocalTime get() = LocalTime.of(hour, minute)
+    override fun toString() = "%02d:%02d".format(hour, minute)
+}
+
+object ShuttleSchedule {
+
+    // Monday–Thursday
+    val loyolaMonThur = listOf(
+        DepartureTime(9,15), DepartureTime(9,30), DepartureTime(9,45),
+        DepartureTime(10,0), DepartureTime(10,15), DepartureTime(10,30),
+        DepartureTime(10,45), DepartureTime(11,0), DepartureTime(11,15),
+        DepartureTime(11,30), DepartureTime(11,45), DepartureTime(12,30),
+        DepartureTime(12,45), DepartureTime(13,0), DepartureTime(13,15),
+        DepartureTime(13,30), DepartureTime(13,45), DepartureTime(14,0),
+        DepartureTime(14,15), DepartureTime(14,30), DepartureTime(14,45),
+        DepartureTime(15,0), DepartureTime(15,15), DepartureTime(15,30),
+        DepartureTime(15,45), DepartureTime(16,30), DepartureTime(16,45),
+        DepartureTime(17,0), DepartureTime(17,15), DepartureTime(17,30),
+        DepartureTime(17,45), DepartureTime(18,0), DepartureTime(18,15),
+        DepartureTime(18,30)
+    )
+
+    val sgwMonThur = listOf(
+        DepartureTime(9,30), DepartureTime(9,45), DepartureTime(10,0),
+        DepartureTime(10,15), DepartureTime(10,30), DepartureTime(10,45),
+        DepartureTime(11,0), DepartureTime(11,15), DepartureTime(11,30),
+        DepartureTime(12,15), DepartureTime(12,30), DepartureTime(12,45),
+        DepartureTime(13,0), DepartureTime(13,15), DepartureTime(13,30),
+        DepartureTime(13,45), DepartureTime(14,0), DepartureTime(14,15),
+        DepartureTime(14,30), DepartureTime(14,45), DepartureTime(15,0),
+        DepartureTime(15,15), DepartureTime(15,30), DepartureTime(16,0),
+        DepartureTime(16,15), DepartureTime(16,45), DepartureTime(17,0),
+        DepartureTime(17,15), DepartureTime(17,30), DepartureTime(17,45),
+        DepartureTime(18,0), DepartureTime(18,15), DepartureTime(18,30)
+    )
+
+    // Friday
+    val loyolaFriday = listOf(
+        DepartureTime(9,15), DepartureTime(9,30), DepartureTime(9,45),
+        DepartureTime(10,15), DepartureTime(10,45), DepartureTime(11,0),
+        DepartureTime(11,15), DepartureTime(12,0), DepartureTime(12,15),
+        DepartureTime(12,45), DepartureTime(13,0), DepartureTime(13,15),
+        DepartureTime(13,45), DepartureTime(14,15), DepartureTime(14,30),
+        DepartureTime(14,45), DepartureTime(15,15), DepartureTime(15,30),
+        DepartureTime(15,45), DepartureTime(16,45), DepartureTime(17,15),
+        DepartureTime(17,45), DepartureTime(18,15)
+    )
+
+    val sgwFriday = listOf(
+        DepartureTime(9,45), DepartureTime(10,0), DepartureTime(10,15),
+        DepartureTime(10,45), DepartureTime(11,15), DepartureTime(11,30),
+        DepartureTime(12,15), DepartureTime(12,30), DepartureTime(12,45),
+        DepartureTime(13,15), DepartureTime(13,45), DepartureTime(14,0),
+        DepartureTime(14,15), DepartureTime(14,45), DepartureTime(15,0),
+        DepartureTime(15,15), DepartureTime(15,45), DepartureTime(16,0),
+        DepartureTime(16,45), DepartureTime(17,15), DepartureTime(17,45),
+        DepartureTime(18,15)
+    )
+
+    /**
+     * Returns the next departure time for a given campus in real time.
+     * Returns null if no more departures today (weekend or after last bus).
+     */
+    fun nextDeparture(campus: Campus, now: ZonedDateTime = ZonedDateTime.now(ZoneId.of("America/Montreal"))): DepartureTime? {
+        val dow = now.dayOfWeek
+        if (dow == DayOfWeek.SATURDAY || dow == DayOfWeek.SUNDAY) return null
+
+        val times = when (campus) {
+            Campus.SGW     -> if (dow == DayOfWeek.FRIDAY) sgwFriday    else sgwMonThur
+            Campus.LOYOLA  -> if (dow == DayOfWeek.FRIDAY) loyolaFriday else loyolaMonThur
+        }
+
+        val currentTime = now.toLocalTime()
+        return times.firstOrNull { it.localTime.isAfter(currentTime) }
+    }
+
+    /**
+     * Returns the next departure on the next operating day, for the
+     * "No more departures today. Next departure: DAY HH:mm" message.
+     */
+    fun nextDepartureNextDay(campus: Campus, now: ZonedDateTime = ZonedDateTime.now(ZoneId.of("America/Montreal"))): Pair<String, DepartureTime>? {
+        val dow = now.dayOfWeek
+        return when (dow) {
+            DayOfWeek.FRIDAY, DayOfWeek.SATURDAY, DayOfWeek.SUNDAY -> {
+                val first = if (campus == Campus.SGW) sgwMonThur.first() else loyolaMonThur.first()
+                Pair("Mon", first)
+            }
+            else -> {
+                val nextDow = dow.plus(1)
+                val isFriday = nextDow == DayOfWeek.FRIDAY
+                val first = when (campus) {
+                    Campus.SGW    -> if (isFriday) sgwFriday.first()    else sgwMonThur.first()
+                    Campus.LOYOLA -> if (isFriday) loyolaFriday.first() else loyolaMonThur.first()
+                }
+                val label = nextDow.name.lowercase().replaceFirstChar { it.uppercase() }.take(3)
+                Pair(label, first)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/campusguide/ui/shuttle/ShuttleTracker.kt
+++ b/app/src/main/java/com/example/campusguide/ui/shuttle/ShuttleTracker.kt
@@ -6,16 +6,14 @@ import com.google.android.gms.maps.model.LatLng
 
 /**
  * Domain class for shuttle bus logic.
- * Applies "Extract Class" refactoring (Fowler) — shuttle logic lives here, not inline in MapScreen.
- * Matches the class diagram: campusStops, isOperational(), getShuttleStops().
  */
 class ShuttleTracker(private val dataSource: ShuttleDataSource = StaticShuttleDataSource()) {
 
-    /** Safely retrieves shuttle stops from the data source, failing gracefully with an empty list. */
+    // retrieves shuttle stops from the data source, failing gracefully with an empty list.
     private fun safeGetShuttleStops(): List<ShuttleStop> =
         runCatching { dataSource.getShuttleStops() }.getOrDefault(emptyList())
 
-    /** Map of campus → list of shuttle stop LatLngs (matches class diagram). */
+    // Map of campus → list of shuttle stop LatLngs
     val campusStops: Map<Campus, List<LatLng>> by lazy {
         safeGetShuttleStops().groupBy(ShuttleStop::campus) { it.latLng }
     }
@@ -25,6 +23,13 @@ class ShuttleTracker(private val dataSource: ShuttleDataSource = StaticShuttleDa
 
     fun getShuttleStops(): List<ShuttleStop> = safeGetShuttleStops()
 
-    /** Stub for US-3.2 — next shuttle time. */
     fun getNextShuttle(): String? = null
+
+    fun getNextShuttleForCampus(campus: Campus): String? {
+        val next = ShuttleSchedule.nextDeparture(campus)
+        if (next != null) return next.toString()
+
+        val nextDay = ShuttleSchedule.nextDepartureNextDay(campus) ?: return null
+        return "Next ${nextDay.first}: ${nextDay.second}"
+    }
 }

--- a/app/src/test/java/com/example/campusguide/ui/shuttle/ShuttleScheduleTest.kt
+++ b/app/src/test/java/com/example/campusguide/ui/shuttle/ShuttleScheduleTest.kt
@@ -1,0 +1,105 @@
+package com.example.campusguide.ui.shuttle
+
+import com.example.campusguide.ui.components.Campus
+import org.junit.Assert.*
+import org.junit.Test
+import java.time.DayOfWeek
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+class ShuttleScheduleTest {
+
+    private val montreal = ZoneId.of("America/Montreal")
+
+    private fun timeOn(dow: DayOfWeek, hour: Int, minute: Int): ZonedDateTime {
+        var dt = ZonedDateTime.of(2026, 1, 12, hour, minute, 0, 0, montreal)
+        while (dt.dayOfWeek != dow) dt = dt.plusDays(1)
+        return dt
+    }
+
+    // AC: displays upcoming departure times relevant to current time
+    @Test
+    fun nextDeparture_duringOperatingHours_returnsUpcomingTime() {
+        val now = timeOn(DayOfWeek.MONDAY, 10, 0)
+        val result = ShuttleSchedule.nextDeparture(Campus.SGW, now)
+        assertNotNull(result)
+        assertTrue(result!!.localTime.isAfter(now.toLocalTime()))
+    }
+
+    // AC: clearly indicates "next departure" for SGW
+    @Test
+    fun nextDeparture_sgw_returnsCorrectNextTime() {
+        val now = timeOn(DayOfWeek.MONDAY, 9, 0)
+        assertEquals(DepartureTime(9, 30), ShuttleSchedule.nextDeparture(Campus.SGW, now))
+    }
+
+    // AC: clearly indicates "next departure" for Loyola
+    @Test
+    fun nextDeparture_loyola_returnsCorrectNextTime() {
+        val now = timeOn(DayOfWeek.MONDAY, 9, 0)
+        assertEquals(DepartureTime(9, 15), ShuttleSchedule.nextDeparture(Campus.LOYOLA, now))
+    }
+
+    // AC: outside operating hours shows "No more shuttles today"
+    @Test
+    fun nextDeparture_afterLastBus_returnsNull() {
+        val now = timeOn(DayOfWeek.MONDAY, 18, 31)
+        assertNull(ShuttleSchedule.nextDeparture(Campus.SGW, now))
+        assertNull(ShuttleSchedule.nextDeparture(Campus.LOYOLA, now))
+    }
+
+    // AC: outside operating hours — weekend
+    @Test
+    fun nextDeparture_weekend_returnsNull() {
+        val now = timeOn(DayOfWeek.SATURDAY, 10, 0)
+        assertNull(ShuttleSchedule.nextDeparture(Campus.SGW, now))
+        assertNull(ShuttleSchedule.nextDeparture(Campus.LOYOLA, now))
+    }
+
+    // AC: next departure on next operating day shown when no more today
+    @Test
+    fun nextDepartureNextDay_afterLastBus_returnsNextDayTime() {
+        val now = timeOn(DayOfWeek.MONDAY, 19, 0)
+        val result = ShuttleSchedule.nextDepartureNextDay(Campus.SGW, now)
+        assertNotNull(result)
+        assertEquals("Tue", result!!.first)
+    }
+
+    // AC: Friday wraps to Monday
+    @Test
+    fun nextDepartureNextDay_friday_returnsMonday() {
+        val now = timeOn(DayOfWeek.FRIDAY, 19, 0)
+        val result = ShuttleSchedule.nextDepartureNextDay(Campus.SGW, now)
+        assertEquals("Mon", result!!.first)
+    }
+
+    // AC: Friday uses correct schedule (different from Mon–Thu)
+    @Test
+    fun nextDeparture_friday_usesFridaySchedule() {
+        val now = timeOn(DayOfWeek.FRIDAY, 9, 0)
+        assertEquals(DepartureTime(9, 45), ShuttleSchedule.nextDeparture(Campus.SGW, now))
+    }
+
+    // AC: schedule data is available (non-empty)
+    @Test
+    fun scheduleData_allListsNonEmpty() {
+        assertTrue(ShuttleSchedule.sgwMonThur.isNotEmpty())
+        assertTrue(ShuttleSchedule.loyolaMonThur.isNotEmpty())
+        assertTrue(ShuttleSchedule.sgwFriday.isNotEmpty())
+        assertTrue(ShuttleSchedule.loyolaFriday.isNotEmpty())
+    }
+
+    // AC: times are in order (screen reader reads them top-to-bottom correctly)
+    @Test
+    fun scheduleData_timesAreSortedAscending() {
+        listOf(
+            ShuttleSchedule.sgwMonThur,
+            ShuttleSchedule.loyolaMonThur,
+            ShuttleSchedule.sgwFriday,
+            ShuttleSchedule.loyolaFriday
+        ).forEach { list ->
+            val times = list.map { it.localTime }
+            assertEquals(times, times.sorted())
+        }
+    }
+}

--- a/app/src/test/java/com/example/campusguide/ui/shuttle/ShuttleTrackerTest.kt
+++ b/app/src/test/java/com/example/campusguide/ui/shuttle/ShuttleTrackerTest.kt
@@ -53,8 +53,16 @@ class ShuttleTrackerTest {
     }
 
     @Test
-    fun `getNextShuttle returns null as stub for US-3_2`() {
-        assertNull(tracker.getNextShuttle())
+    fun `getNextShuttleForCampus returns string or null for SGW`() {
+        // Returns either a time string or null, but should never throw or return blank string.
+        val result = tracker.getNextShuttleForCampus(Campus.SGW)
+        if (result != null) assertTrue(result.isNotBlank())
+    }
+
+    @Test
+    fun `getNextShuttleForCampus returns string or null for Loyola`() {
+        val result = tracker.getNextShuttleForCampus(Campus.LOYOLA)
+        if (result != null) assertTrue(result.isNotBlank())
     }
 
     @Test


### PR DESCRIPTION
## Summary
Implements US-3.2 - View shuttle schedule information based on current time.

## Changes
- Added `ShuttleSchedule` object with full Winter 2026 timetable data (Mon–Thu and Friday)
- Added `nextDeparture()` logic returning the next upcoming bus for SGW or Loyola
- Added `nextDepartureNextDay()` for "no more shuttles today" case
- Updated `ShuttleTracker` replacing stub `getNextShuttle()` with `getNextShuttleForCampus()`
- Updated `ShuttleStopInfoCard` to display next departure time and "View full schedule" button
- Added `ShuttleScheduleDialog` showing the full scrollable semester schedule

## Tests Added
- `ShuttleScheduleTest`

## Closes
#202
