### PR TITLE
Update sonar-project.properties

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,10 +7,15 @@ sonar.sourceEncoding=UTF-8
 # Source paths
 sonar.sources=app/src/main/java
 sonar.tests=app/src/test/java
-sonar.java.binaries=app/build/intermediates/built_in_kotlinc/debug/compileDebugKotlin/classes
+
+# Compiled class directories (standalone sonar-scanner needs these to correlate JaCoCo coverage)
+sonar.java.binaries=\
+  app/build/intermediates/built_in_kotlinc/debug/compileDebugKotlin/classes,\
+  app/build/intermediates/javac/debug/compileDebugJavaWithJavac/classes,\
+  app/build/tmp/kotlin-classes/debug,\
+  app/build/intermediates/classes/debug
 
 # JaCoCo coverage
-sonar.java.coveragePlugin=jacoco
 sonar.coverage.jacoco.xmlReportPaths=app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml
 
 # JUnit test results


### PR DESCRIPTION
This pull request updates the SonarQube configuration to improve code coverage analysis and binary mapping. The most significant change is the expansion of the `sonar.java.binaries` property to include multiple compiled class directories, which helps SonarQube better correlate JaCoCo coverage reports with the source code.

Configuration improvements:

* Expanded the `sonar.java.binaries` property in `sonar-project.properties` to include additional class output directories: `javac`, `kotlin-classes`, and `classes` intermediates, in addition to the existing Kotlin output. This ensures SonarQube can accurately map coverage data from JaCoCo to the correct classes.