### PR TITLE
Fix: Merge shuttle and building search results + extract ShuttleViewModel

### DIFF
--- a/app/src/main/java/com/example/campusguide/MainActivity.kt
+++ b/app/src/main/java/com/example/campusguide/MainActivity.kt
@@ -53,9 +53,9 @@ import com.example.campusguide.ui.directions.TravelMode
 import com.example.campusguide.ui.screens.DirectionsTopBarState
 import com.example.campusguide.ui.components.DirectionsTopBar
 import com.example.campusguide.ui.viewmodels.ControlsViewModel
-import com.example.campusguide.ui.shuttle.ShuttleTracker
-import com.google.android.gms.location.LocationServices
-import com.google.android.gms.maps.model.LatLng as GmsLatLng
+import com.example.campusguide.ui.viewmodels.ShuttleViewModel
+
+
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -99,10 +99,7 @@ fun ConcordiaCampusGuideApp() {
     var searchQuery by rememberSaveable { mutableStateOf("") }
     var searchCounter by rememberSaveable { mutableStateOf(0) }
     var topBarSuggestions by remember { mutableStateOf<List<com.example.campusguide.data.CampusBuilding>>(emptyList()) }
-    var shuttleStops by remember { mutableStateOf<List<com.example.campusguide.data.ShuttleStop>>(emptyList()) }
-    var shuttleUserLatLng by remember { mutableStateOf<com.google.android.gms.maps.model.LatLng?>(null) }
     var topBarSelectedBuilding by remember { mutableStateOf<com.example.campusguide.data.CampusBuilding?>(null) }
-    var shuttleShowBothStops by remember { mutableStateOf(false) }
     val searchFocusRequester = remember { FocusRequester() }
     val context = LocalContext.current
     var directionsTopBarState by remember { mutableStateOf(DirectionsTopBarState(active = false)) }
@@ -112,6 +109,8 @@ fun ConcordiaCampusGuideApp() {
     var myLocationTrigger by remember { mutableStateOf(0) }
     var topBarTravelMode by remember { mutableStateOf(TravelMode.DRIVE) }
     val viewModel = viewModel<ControlsViewModel>()
+    val shuttleViewModel = viewModel<ShuttleViewModel>()
+
 
     val locationPermissionLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestMultiplePermissions(),
@@ -166,8 +165,9 @@ fun ConcordiaCampusGuideApp() {
                             originPickTrigger = originPickTrigger,
                             myLocationTrigger = myLocationTrigger,
                             topBarTravelMode = topBarTravelMode,
-                            shuttleShowBothStops = shuttleShowBothStops,
-                            onShuttleShowBothStopsConsumed = { shuttleShowBothStops = false },
+                            shuttleShowBothStops = shuttleViewModel.shuttleShowBothStops,
+                            onShuttleShowBothStopsConsumed = { shuttleViewModel.consumeShowBothStops() },
+
                         )
                         AppDestinations.CALENDAR -> CalendarScreen()
                         AppDestinations.POI -> PlaceholderScreen("POI Screen", modifier)
@@ -200,32 +200,15 @@ fun ConcordiaCampusGuideApp() {
                             modifier = Modifier.padding(top = 35.dp),
                             focusRequester = searchFocusRequester,
                             onSearchQueryChange = { query ->
-                                if ("shuttle".startsWith(query.trim().lowercase()) && query.trim().isNotEmpty()) {                                    topBarSuggestions = emptyList()
-                                    val tracker = ShuttleTracker()
-                                    shuttleStops = tracker.getShuttleStops()
-                                    val fused = LocationServices.getFusedLocationProviderClient(context)
-                                    val fineGranted = ContextCompat.checkSelfPermission(
-                                        context, Manifest.permission.ACCESS_FINE_LOCATION
-                                    ) == PackageManager.PERMISSION_GRANTED
-                                    if (fineGranted) {
-                                        fused.lastLocation.addOnSuccessListener { loc ->
-                                            shuttleUserLatLng = loc?.let { GmsLatLng(it.latitude, it.longitude) }
-                                        }
-                                    }
-                                } else {
-                                    shuttleStops = emptyList()
-                                    shuttleUserLatLng = null
-                                    topBarSuggestions = com.example.campusguide.data.buildingSuggestions(
-                                        query = query,
-                                        activeCampus = com.example.campusguide.ui.components.Campus.SGW,
-                                        crossCampus = true,
-                                    )
-                                }
+                                topBarSuggestions = com.example.campusguide.data.buildingSuggestions(
+                                    query = query,
+                                    activeCampus = com.example.campusguide.ui.components.Campus.SGW,
+                                    crossCampus = true,
+                                )
+                                // Additionally show shuttle stops if query matches
+                                shuttleViewModel.handleSearchQuery(query, context)
                             },
                             onSearchSubmit = { query ->
-                                if ("shuttle".startsWith(query.trim().lowercase()) && query.trim().isNotEmpty()) {
-                                    return@SearchBarWithProfile
-                                }
                                 val matchedBuilding = com.example.campusguide.data.ALL_CAMPUS_BUILDINGS
                                     .firstOrNull { it.matches(query) }
                                 if (matchedBuilding != null) {
@@ -249,11 +232,10 @@ fun ConcordiaCampusGuideApp() {
                                 searchQuery = ""
                                 currentDestination.value = AppDestinations.MAP
                             },
-                            shuttleStops = shuttleStops,
-                            shuttleUserLatLng = shuttleUserLatLng,
+                            shuttleStops = shuttleViewModel.shuttleStops,
+                            shuttleUserLatLng = shuttleViewModel.shuttleUserLatLng,
                             onShuttleStopSelected = { _ ->
-                                shuttleStops = emptyList()
-                                shuttleShowBothStops = true
+                                shuttleViewModel.onShuttleStopSelected()
                                 currentDestination.value = AppDestinations.MAP
                             },
                         )

--- a/app/src/main/java/com/example/campusguide/ui/viewmodels/ShuttleViewModel.kt
+++ b/app/src/main/java/com/example/campusguide/ui/viewmodels/ShuttleViewModel.kt
@@ -1,0 +1,72 @@
+package com.example.campusguide.ui.viewmodels
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.ViewModel
+import com.example.campusguide.data.ShuttleStop
+import com.example.campusguide.ui.shuttle.ShuttleTracker
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.maps.model.LatLng
+
+class ShuttleViewModel : ViewModel() {
+
+    var shuttleStops by mutableStateOf<List<ShuttleStop>>(emptyList())
+        private set
+
+    var shuttleUserLatLng by mutableStateOf<LatLng?>(null)
+        private set
+
+    var shuttleShowBothStops by mutableStateOf(false)
+        private set
+
+    fun handleSearchQuery(query: String, context: Context): Boolean {
+        val trimmed = query.trim().lowercase()
+
+        if (trimmed.length >= 2 && "shuttle".startsWith(trimmed)) {
+            val tracker = ShuttleTracker()
+            shuttleStops = tracker.getShuttleStops()
+            fetchUserLocation(context)
+            return true
+        }
+
+        clearShuttleState()
+        return false
+    }
+
+    fun isShuttleQuery(query: String): Boolean {
+        val trimmed = query.trim().lowercase()
+        return trimmed.length >= 2 && "shuttle".startsWith(trimmed)
+    }
+
+    fun onShuttleStopSelected() {
+        shuttleStops = emptyList()
+        shuttleShowBothStops = true
+    }
+
+    fun consumeShowBothStops() {
+        shuttleShowBothStops = false
+    }
+
+    private fun clearShuttleState() {
+        shuttleStops = emptyList()
+        shuttleUserLatLng = null
+    }
+
+    private fun fetchUserLocation(context: Context) {
+        val fineGranted = ContextCompat.checkSelfPermission(
+            context, Manifest.permission.ACCESS_FINE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED
+
+        if (fineGranted) {
+            val fused = LocationServices.getFusedLocationProviderClient(context)
+            fused.lastLocation.addOnSuccessListener { loc ->
+                shuttleUserLatLng = loc?.let { LatLng(it.latitude, it.longitude) }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What was done

Fixed the shuttle stop search blocking building suggestions and refactored the shuttle logic out of MainActivity.

- Building suggestions and shuttle stop suggestions now display together when the search query matches both (e.g., typing "sh" shows buildings starting with SH alongside shuttle stops)
- Extracted all shuttle state (`shuttleStops`, `shuttleUserLatLng`, `shuttleShowBothStops`) and related logic into a new `ShuttleViewModel` to reduce complexity in `MainActivity.kt`
- Removed the early return in `onSearchSubmit` that prevented building a search when the query matched a shuttle prefix

## Note

The main issue was the `if/else` branch in `onSearchQueryChange`. When the query matched "shuttle" as a prefix (even just "s"), building suggestions were cleared, and only shuttle results appeared. The fix runs both searches in parallel, so neither blocks the other.

The `ShuttleViewModel` follows the same pattern as the existing `ControlsViewModel`.

Closes #226