### PR TITLE
Fix Bug #179: Clicking on Map Markers creates a GoogleMaps Hyperlink Button

### DIFF
--- a/app/src/main/java/com/example/campusguide/ui/screens/map/MapScreen.kt
+++ b/app/src/main/java/com/example/campusguide/ui/screens/map/MapScreen.kt
@@ -1187,6 +1187,7 @@ fun MapScreen(
 
                         // Marker click: handle shuttle stop taps (US-3.1)
                         // GeoJsonOverlay uses polygon listeners, not marker listeners — safe to set here.
+                        @Suppress("PotentialBehaviorOverride")
                         map.setOnMarkerClickListener { marker -> // NOSONAR
                             val stop = marker.tag as? ShuttleStop
                             if (stop != null) {


### PR DESCRIPTION
A very small line addition that solves the problem.

Simply setting a change in the map ui settings when starting.

Closes #179