### PR TITLE
Update indoor asset labels and types for Hall Building floors 8 and 9

### DIFF
--- a/app/src/main/assets/indoor/hall_floor_8.json
+++ b/app/src/main/assets/indoor/hall_floor_8.json
@@ -267,20 +267,20 @@
     },
     {
       "id": "H-8-890",
-      "label": "STAIRS 1",
+      "label": "EMERGENCY-STAIR-1",
       "x": 308.54,
       "y": 735.31,
-      "type": "STAIRCASE",
+      "type": "POI",
       "floor": 8,
       "buildingCode": "H",
       "description": null
     },
     {
       "id": "H-8-88",
-      "label": "STAIRS 2",
+      "label": "EMERGENCY-STAIR-2",
       "x": 303.8,
       "y": 299.48,
-      "type": "STAIRCASE",
+      "type": "POI",
       "floor": 8,
       "buildingCode": "H",
       "description": null
@@ -497,20 +497,20 @@
     },
     {
       "id": "H-8-804",
-      "label": "BATHROOM-W",
+      "label": "BATHROOM-F",
       "x": 582.17,
       "y": 750.92,
-      "type": "ROOM",
+      "type": "POI",
       "floor": 8,
       "buildingCode": "H",
       "description": null
     },
     {
       "id": "H-8-892",
-      "label": "BATHROOM",
+      "label": "BATHROOM-WC",
       "x": 596.3,
       "y": 668.08,
-      "type": "ROOM",
+      "type": "POI",
       "floor": 8,
       "buildingCode": "H",
       "description": null
@@ -520,7 +520,7 @@
       "label": "BATHROOM-M",
       "x": 391.44,
       "y": 710.46,
-      "type": "ROOM",
+      "type": "POI",
       "floor": 8,
       "buildingCode": "H",
       "description": null
@@ -607,20 +607,20 @@
     },
     {
       "id": "H-8-898",
-      "label": "STAIRS-3",
+      "label": "EMERGENCY-STAIR-3",
       "x": 773.74,
       "y": 710.42,
-      "type": "STAIRCASE",
+      "type": "POI",
       "floor": 8,
       "buildingCode": "H",
       "description": null
     },
     {
       "id": "H-8-875",
-      "label": "STAIRS-4",
+      "label": "EMERGENCY-STAIR-4",
       "x": 715.46,
       "y": 293.5,
-      "type": "STAIRCASE",
+      "type": "POI",
       "floor": 8,
       "buildingCode": "H",
       "description": null

--- a/app/src/main/assets/indoor/hall_floor_9.json
+++ b/app/src/main/assets/indoor/hall_floor_9.json
@@ -1057,40 +1057,40 @@
     },
     {
       "id": "H-9-998",
-      "label": "STAIRCASE",
+      "label": "EMERGENCY-STAIR-3",
       "x": 267.59,
       "y": 332.57,
-      "type": "STAIRCASE",
+      "type": "POI",
       "floor": 9,
       "buildingCode": "H",
       "description": null
     },
     {
       "id": "H-9-985",
-      "label": "STAIRCASE",
+      "label": "EMERGENCY-STAIR-2",
       "x": 716.47,
       "y": 718.6,
-      "type": "STAIRCASE",
+      "type": "POI",
       "floor": 9,
       "buildingCode": "H",
       "description": null
     },
     {
       "id": "H-9-975",
-      "label": "STAIRCASE",
+      "label": "EMERGENCY-STAIR-4",
       "x": 298.1,
       "y": 718.6,
-      "type": "STAIRCASE",
+      "type": "POI",
       "floor": 9,
       "buildingCode": "H",
       "description": null
     },
     {
       "id": "H-9-990",
-      "label": "STAIRCASE",
+      "label": "EMERGENCY-STAIR-1",
       "x": 720.27,
       "y": 291.35,
-      "type": "STAIRCASE",
+      "type": "POI",
       "floor": 9,
       "buildingCode": "H",
       "description": null


### PR DESCRIPTION
Updated various indoor map locations in `hall_floor_8.json` and `hall_floor_9.json`:
- Renamed stairs to 'EMERGENCY-STAIR' with specific numbering.
- Updated bathroom labels (e.g., 'BATHROOM-W' to 'BATHROOM-F' and added 'BATHROOM-WC').
- Changed location types from 'STAIRCASE' and 'ROOM' to 'POI'.