### PR TITLE
First Usability Improvement

### DIFF
--- a/app/src/main/java/com/example/campusguide/MainActivity.kt
+++ b/app/src/main/java/com/example/campusguide/MainActivity.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Place
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenuItem
@@ -646,6 +647,12 @@ fun ConcordiaCampusGuideApp() {
 
 
                                     }
+                                    AppDestinations.ACCESSIBILITY ->{
+                                        AccessibilityScreen(
+                                            onBackClick = { currentDestination.value =
+                                                AppDestinations.MAP }
+                                        )
+                                    }
 
                                 }
                             }
@@ -807,6 +814,7 @@ enum class AppDestinations(
     MAP("Map", AppIcon.Vector(Icons.Default.Place)),
     CALENDAR("Calendar", AppIcon.Drawable(R.drawable.ic_calendar)),
     POI("POI", AppIcon.Drawable(R.drawable.poi_icon)),
+    ACCESSIBILITY("Settings", AppIcon.Vector(Icons.Default.Settings)),
 }
 
 

--- a/app/src/test/java/com/example/campusguide/MainActivityTest.kt
+++ b/app/src/test/java/com/example/campusguide/MainActivityTest.kt
@@ -74,12 +74,14 @@ class MainActivityTest {
     fun appDestinations_enumHasCorrectValues() {
         // Test that AppDestinations enum has the expected values
         val destinations = AppDestinations.entries
-        assertEquals("Should have 3 destinations", 3, destinations.size)
+        assertEquals("Should have 4 destinations", 4, destinations.size)
 
         val labels = destinations.map { it.label }
         assertTrue("Should contain Map", labels.contains("Map"))
         assertTrue("Should contain Calendar", labels.contains("Calendar"))
         assertTrue("Should contain POI", labels.contains("POI"))
+        assertTrue("Should contain Settings", labels.contains("Settings"))
+
     }
 
     @Test
@@ -129,10 +131,13 @@ class MainActivityTest {
         val mapIcon = AppDestinations.MAP.icon
         val calendarIcon = AppDestinations.CALENDAR.icon
         val poiIcon = AppDestinations.POI.icon
+        val accessibilityIcon = AppDestinations.ACCESSIBILITY.icon
 
         assertNotNull("Map icon should exist", mapIcon)
         assertNotNull("Calendar icon should exist", calendarIcon)
         assertNotNull("POI icon should exist", poiIcon)
+        assertNotNull("POI icon should exist", accessibilityIcon)
+
     }
 
     @Test


### PR DESCRIPTION
Add accessibility settings navigation option on navbar. This is a response to user feedback describing accessibility settinsg location unintuitiveness. Both paths to reach the settings are available now.

Added the option to corresponding unit tests.

Closes #296